### PR TITLE
feat: Move brew installation to a separate script file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Suggested execution order:
 
 ```shell
 # Install homebrew and all the packages listed in the Brewfile
-$ task homebrew
+#
+# It cannot be done via Taskfile.yaml simply because task CLI has to be installed first
+$ ./init.sh
 
 # Install Zim Framework (zimfw)
 $ task zimfw

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,15 +14,6 @@ tasks:
     cmds:
       - curl -fsSL https://raw.githubusercontent.com/zimfw/install/master/install.zsh | zsh
 
-  homebrew:
-    desc: "Install homebrew"
-    preconditions:
-      - sh: "! command -v brew"
-        msg: "homebrew seems to be already installed (brew binary exist)"
-    cmds:
-      - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-      - brew bundle install
-
   brewfile:
     desc: "Dump brew packages to Brewfile"
     cmds:

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit
+# errtrace is required to handle ERR trap correctly
+#
+# Further reading: https://stackoverflow.com/a/35800451/6802186
+set -o errtrace
+set -o pipefail
+set -o nounset
+
+if [[ $(command -v brew) == "" ]]; then
+  echo "Intalling brew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+else
+  echo "brew is already installed"
+fi
+
+brew bundle install


### PR DESCRIPTION
It's been a classic "chicken-and-egg" problem - `brew` has to be installed first (outside of `Taskfile.yaml`) in order to make `task` CLI available. 